### PR TITLE
Support building Parallels boxes using packer 0.7.0

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,4 +3,5 @@
 #
 Mischa Taylor <mischa@misheska.com>
 Nan Liu <nan.liu@gmail.com>
+Rickard von Essen <rickard.von.essen@gmail.com>
 Ross Smith II <ross@smithii.com>

--- a/Makefile
+++ b/Makefile
@@ -37,17 +37,20 @@ ifeq ($(CM),nocm)
 else
 	BOX_SUFFIX := -$(CM)$(CM_VERSION).box
 endif
-BUILDER_TYPES := vmware virtualbox
+BUILDER_TYPES := vmware virtualbox parallels
 TEMPLATE_FILENAMES := $(wildcard *.json)
 BOX_FILENAMES := $(TEMPLATE_FILENAMES:.json=$(BOX_SUFFIX))
 BOX_FILES := $(foreach builder, $(BUILDER_TYPES), $(foreach box_filename, $(BOX_FILENAMES), box/$(builder)/$(box_filename)))
 TEST_BOX_FILES := $(foreach builder, $(BUILDER_TYPES), $(foreach box_filename, $(BOX_FILENAMES), test-box/$(builder)/$(box_filename)))
 VMWARE_BOX_DIR := box/vmware
 VIRTUALBOX_BOX_DIR := box/virtualbox
+PARALLELS_BOX_DIR := box/parallels
 VMWARE_OUTPUT := output-vmware-iso
 VIRTUALBOX_OUTPUT := output-virtualbox-iso
+PARALLELS_OUTPUT := output-parallels-iso
 VMWARE_BUILDER := vmware-iso
 VIRTUALBOX_BUILDER := virtualbox-iso
+PARALLELS_BUILDER := parallels-iso
 CURRENT_DIR = $(shell pwd)
 SOURCES := $(wildcard script/*.sh)
 
@@ -69,9 +72,13 @@ virtualbox/$(1): $(VIRTUALBOX_BOX_DIR)/$(1)$(BOX_SUFFIX)
 
 test-virtualbox/$(1): test-$(VIRTUALBOX_BOX_DIR)/$(1)$(BOX_SUFFIX)
 
-$(1): vmware/$(1) virtualbox/$(1)
+parallels/$(1): $(PARALLELS_BOX_DIR)/$(1)$(BOX_SUFFIX)
 
-test-$(1): test-vmware/$(1) test-virtualbox/$(1)
+test-parallels/$(1): test-$(PARALLELS_BOX_DIR)/$(1)$(BOX_SUFFIX)
+
+$(1): vmware/$(1) virtualbox/$(1) parallels/$(1)
+
+test-$(1): test-vmware/$(1) test-virtualbox/$(1) test-parallels/$(1)
 
 endef
 
@@ -167,7 +174,7 @@ $(VMWARE_BOX_DIR)/oracle57-i386$(BOX_SUFFIX): oracle57-i386.json $(SOURCES) http
 #	rm -rf output-virtualbox-iso
 #	mkdir -p $(VIRTUALBOX_BOX_DIR)
 #	packer build -only=virtualbox-iso $(PACKER_VARS) $<
-	
+
 $(VIRTUALBOX_BOX_DIR)/oracle70$(BOX_SUFFIX): oracle70.json $(SOURCES) http/ks7.cfg
 	rm -rf $(VIRTUALBOX_OUTPUT)
 	mkdir -p $(VIRTUALBOX_BOX_DIR)
@@ -243,8 +250,90 @@ $(VIRTUALBOX_BOX_DIR)/oracle57-i386$(BOX_SUFFIX): oracle57-i386.json $(SOURCES) 
 	mkdir -p $(VIRTUALBOX_BOX_DIR)
 	packer build -only=$(VIRTUALBOX_BUILDER) $(PACKER_VARS) -var "iso_url=$(ORACLE57_I386)" $<
 
+# Generic rule - not used currently
+#$(PARALLELS_BOX_DIR)/%$(BOX_SUFFIX): %.json
+#	cd $(dir $<)
+#	rm -rf output-parallels-iso
+#	mkdir -p $(PARALLELS_BOX_DIR)
+#	packer build -only=parallels-iso $(PACKER_VARS) $<
+
+$(PARALLELS_BOX_DIR)/oracle70$(BOX_SUFFIX): oracle70.json $(SOURCES) http/ks7.cfg
+	rm -rf $(PARALLELS_OUTPUT)
+	mkdir -p $(PARALLELS_BOX_DIR)
+	packer build -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(ORACLE70_X86_64)" $<
+
+$(PARALLELS_BOX_DIR)/oracle70-desktop$(BOX_SUFFIX): oracle70-desktop.json $(SOURCES) http/ks7-desktop.cfg
+	rm -rf $(PARALLELS_OUTPUT)
+	mkdir -p $(PARALLELS_BOX_DIR)
+	packer build -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(ORACLE70_X86_64)" $<
+
+$(PARALLELS_BOX_DIR)/oracle65$(BOX_SUFFIX): oracle65.json $(SOURCES) http/ks6.cfg
+	rm -rf $(PARALLELS_OUTPUT)
+	mkdir -p $(PARALLELS_BOX_DIR)
+	packer build -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(ORACLE65_X86_64)" $<
+
+$(PARALLELS_BOX_DIR)/oracle65-desktop$(BOX_SUFFIX): oracle65-desktop.json $(SOURCES) http/ks6-desktop.cfg
+	rm -rf $(PARALLELS_OUTPUT)
+	mkdir -p $(PARALLELS_BOX_DIR)
+	packer build -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(ORACLE65_X86_64)" $<
+
+$(PARALLELS_BOX_DIR)/oracle64$(BOX_SUFFIX): oracle64.json $(SOURCES) http/ks6.cfg
+	rm -rf $(PARALLELS_OUTPUT)
+	mkdir -p $(PARALLELS_BOX_DIR)
+	packer build -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(ORACLE64_X86_64)" $<
+
+$(PARALLELS_BOX_DIR)/oracle510$(BOX_SUFFIX): oracle510.json $(SOURCES) http/ks5.cfg
+	rm -rf $(PARALLELS_OUTPUT)
+	mkdir -p $(PARALLELS_BOX_DIR)
+	packer build -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(ORACLE510_X86_64)" $<
+
+$(PARALLELS_BOX_DIR)/oracle59$(BOX_SUFFIX): oracle59.json $(SOURCES) http/ks5.cfg
+	rm -rf $(PARALLELS_OUTPUT)
+	mkdir -p $(PARALLELS_BOX_DIR)
+	packer build -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(ORACLE59_X86_64)" $<
+
+$(PARALLELS_BOX_DIR)/oracle58$(BOX_SUFFIX): oracle58.json $(SOURCES) http/ks5.cfg
+	rm -rf $(PARALLELS_OUTPUT)
+	mkdir -p $(PARALLELS_BOX_DIR)
+	packer build -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(ORACLE58_X86_64)" $<
+
+$(PARALLELS_BOX_DIR)/oracle57$(BOX_SUFFIX): oracle57.json $(SOURCES) http/ks5.cfg
+	rm -rf $(PARALLELS_OUTPUT)
+	mkdir -p $(PARALLELS_BOX_DIR)
+	packer build -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(ORACLE57_X86_64)" $<
+
+$(PARALLELS_BOX_DIR)/oracle65-i386$(BOX_SUFFIX): oracle65-i386.json $(SOURCES) http/ks6.cfg
+	rm -rf $(PARALLELS_OUTPUT)
+	mkdir -p $(PARALLELS_BOX_DIR)
+	packer build -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(ORACLE65_I386)" $<
+
+$(PARALLELS_BOX_DIR)/oracle64-i386$(BOX_SUFFIX): oracle64-i386.json $(SOURCES) http/ks6.cfg
+	rm -rf $(PARALLELS_OUTPUT)
+	mkdir -p $(PARALLELS_BOX_DIR)
+	packer build -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(ORACLE64_I386)" $<
+
+$(PARALLELS_BOX_DIR)/oracle510-i386$(BOX_SUFFIX): oracle510-i386.json $(SOURCES) http/ks5.cfg
+	rm -rf $(PARALLELS_OUTPUT)
+	mkdir -p $(PARALLELS_BOX_DIR)
+	packer build -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(ORACLE510_I386)" $<
+
+$(PARALLELS_BOX_DIR)/oracle59-i386$(BOX_SUFFIX): oracle59-i386.json $(SOURCES) http/ks5.cfg
+	rm -rf $(PARALLELS_OUTPUT)
+	mkdir -p $(PARALLELS_BOX_DIR)
+	packer build -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(ORACLE59_I386)" $<
+
+$(PARALLELS_BOX_DIR)/oracle58-i386$(BOX_SUFFIX): oracle58-i386.json $(SOURCES) http/ks5.cfg
+	rm -rf $(PARALLELS_OUTPUT)
+	mkdir -p $(PARALLELS_BOX_DIR)
+	packer build -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(ORACLE58_I386)" $<
+
+$(PARALLELS_BOX_DIR)/oracle57-i386$(BOX_SUFFIX): oracle57-i386.json $(SOURCES) http/ks5.cfg
+	rm -rf $(PARALLELS_OUTPUT)
+	mkdir -p $(PARALLELS_BOX_DIR)
+	packer build -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(ORACLE57_I386)" $<
+
 list:
-	@echo "prepend 'vmware/' or 'virtualbox/' to build only one target platform:"
+	@echo "prepend 'vmware/', 'virtualbox/' or 'parallels/' to build only one target platform:"
 	@echo "  make vmware/oracle65"
 	@echo ""
 	@echo "Targets:"
@@ -259,7 +348,7 @@ validate:
 	done
 
 clean: clean-builders clean-output clean-packer-cache
-		
+
 clean-builders:
 	@for builder in $(BUILDER_TYPES) ; do \
 		if test -d box/$$builder ; then \
@@ -267,25 +356,31 @@ clean-builders:
 			find box/$$builder -maxdepth 1 -type f -name "*.box" ! -name .gitignore -exec rm '{}' \; ; \
 		fi ; \
 	done
-	
+
 clean-output:
 	@for builder in $(BUILDER_TYPES) ; do \
 		echo Deleting output-$$builder-iso ; \
 		echo rm -rf output-$$builder-iso ; \
 	done
-	
+
 clean-packer-cache:
 	echo Deleting packer_cache
 	rm -rf packer_cache
 
 test-$(VMWARE_BOX_DIR)/%$(BOX_SUFFIX): $(VMWARE_BOX_DIR)/%$(BOX_SUFFIX)
 	bin/test-box.sh $< vmware_desktop vmware_fusion $(CURRENT_DIR)/test/*_spec.rb
-	
+
 test-$(VIRTUALBOX_BOX_DIR)/%$(BOX_SUFFIX): $(VIRTUALBOX_BOX_DIR)/%$(BOX_SUFFIX)
 	bin/test-box.sh $< virtualbox virtualbox $(CURRENT_DIR)/test/*_spec.rb
-	
+
+test-$(PARALLELS_BOX_DIR)/%$(BOX_SUFFIX): $(PARALLELS_BOX_DIR)/%$(BOX_SUFFIX)
+	bin/test-box.sh $< parallels parallels $(CURRENT_DIR)/test/*_spec.rb
+
 ssh-$(VMWARE_BOX_DIR)/%$(BOX_SUFFIX): $(VMWARE_BOX_DIR)/%$(BOX_SUFFIX)
 	bin/ssh-box.sh $< vmware_desktop vmware_fusion $(CURRENT_DIR)/test/*_spec.rb
-	
+
 ssh-$(VIRTUALBOX_BOX_DIR)/%$(BOX_SUFFIX): $(VIRTUALBOX_BOX_DIR)/%$(BOX_SUFFIX)
-	bin/ssh-box.sh $< virtualbox virtualbox $(CURRENT_DIR)/test/*_spec.rb	
+	bin/ssh-box.sh $< virtualbox virtualbox $(CURRENT_DIR)/test/*_spec.rb
+
+ssh-$(PARALLELS_BOX_DIR)/%$(BOX_SUFFIX): $(PARALLELS_BOX_DIR)/%$(BOX_SUFFIX)
+	bin/ssh-box.sh $< parallels parallels $(CURRENT_DIR)/test/*_spec.rb	

--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ Vagrant boxes using Packer.
 
 ## Building the Vagrant boxes
 
-To build all the boxes, you will need Packer and both VirtualBox and VMware Fusion
-installed.
+To build all the boxes, you will need Packer and both VirtualBox, VMware
+Fusion, and Parallels Desktop for Mac installed.
 
 A GNU Make `Makefile` drives the process via the following targets:
 
-    make        # Build all the box types (VirtualBox & VMware)
+    make        # Build all the box types (VirtualBox, VMware & Parallels)
     make test   # Run tests against all the boxes
     make list   # Print out individual targets
     make clean  # Clean up build detritus
@@ -52,14 +52,14 @@ process, should you be using a proxy:
 * ftp_proxy
 * rsync_proxy
 * no_proxy
-    
+
 ### Tests
 
 The tests are written in [Serverspec](http://serverspec.org) and require the
 `vagrant-serverspec` plugin to be installed with:
 
     vagrant plugin install vagrant-serverspec
-    
+
 The `Makefile` has individual targets for each box type with the prefix
 `test-*` should you wish to run tests individually for each box.
 
@@ -68,11 +68,9 @@ newly-built box with vagrant and for logging in using just one command to
 do exploratory testing.  For example, to do exploratory testing
 on the VirtualBox training environmnet, run the following command:
 
-    make ssh-box/virtualbox/centos65-nocm.box
-    
-Upon logout `make ssh-*` will automatically de-register the box as well.
+    make ssh-box/virtualbox/oel65-nocm.box
 
-### Makefile.local override
+Upon logout `make ssh-*` will automatically de-register the box as well.
 
 ### Makefile.local override
 
@@ -115,7 +113,7 @@ default is to not apply OS updates by default.  When `UPDATE := true`,
 the latest OS updates will be applied.
 
 Another use for `Makefile.local` is to override the default locations
-for the Ubuntu install ISO files.
+for the Oracle Enterprise Linux install ISO files.
 
 For Oracle Enterprise Linux, the ISO path variables are:
 

--- a/oracle510-i386.json
+++ b/oracle510-i386.json
@@ -60,6 +60,29 @@
       ["modifyvm", "{{.Name}}", "--memory", "512"],
       ["modifyvm", "{{.Name}}", "--cpus", "1"]
     ]
+  },
+  {
+    "vm_name": "oracle510-i386",
+    "type": "parallels-iso",
+    "http_directory": "http",
+    "iso_url": "{{ user `iso_url` }}",
+    "iso_checksum": "{{ user `iso_checksum` }}",
+    "iso_checksum_type": "md5",
+    "parallels_tools_flavor": "lin",
+    "guest_os_type": "redhat",
+    "prlctl_version_file": ".prlct_version",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_wait_timeout": "10000s",
+    "boot_command": [
+      "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort}}/ks5.cfg<enter>"
+    ],
+    "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -h now",
+    "disk_size": 10140,
+    "prlctl": [
+      ["set", "{{.Name}}", "--memsize", "512"],
+      ["set", "{{.Name}}", "--cpus", "1"]
+    ]
   }],
   "provisioners": [{
     "type": "shell",

--- a/oracle510.json
+++ b/oracle510.json
@@ -60,6 +60,29 @@
       ["modifyvm", "{{.Name}}", "--memory", "512"],
       ["modifyvm", "{{.Name}}", "--cpus", "1"]
     ]
+  },
+  {
+    "vm_name": "oracle510",
+    "type": "parallels-iso",
+    "http_directory": "http",
+    "iso_url": "{{ user `iso_url` }}",
+    "iso_checksum": "{{ user `iso_checksum` }}",
+    "iso_checksum_type": "md5",
+    "parallels_tools_flavor": "lin",
+    "guest_os_type": "redhat",
+    "prlctl_version_file": ".prlctl_version",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_wait_timeout": "10000s",
+    "boot_command": [
+      "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort}}/ks5.cfg<enter>"
+    ],
+    "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -h now",
+    "disk_size": 10140,
+    "prlctl": [
+      ["set", "{{.Name}}", "--memsize", "512"],
+      ["set", "{{.Name}}", "--cpus", "1"]
+    ]
   }],
   "provisioners": [{
     "type": "shell",

--- a/oracle57-i386.json
+++ b/oracle57-i386.json
@@ -60,6 +60,29 @@
       ["modifyvm", "{{.Name}}", "--memory", "512"],
       ["modifyvm", "{{.Name}}", "--cpus", "1"]
     ]
+  },
+  {
+    "vm_name": "oracle57-i386",
+    "type": "parallels-iso",
+    "http_directory": "http",
+    "iso_url": "{{ user `iso_url` }}",
+    "iso_checksum": "{{ user `iso_checksum` }}",
+    "iso_checksum_type": "md5",
+    "parallels_tools_flavor": "lin",
+    "guest_os_type": "redhat",
+    "prlctl_version_file": ".prlctl_version",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_wait_timeout": "10000s",
+    "boot_command": [
+      "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort}}/ks5.cfg<enter>"
+    ],
+    "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -h now",
+    "disk_size": 10140,
+    "prlctl": [
+      ["set", "{{.Name}}", "--memsize", "512"],
+      ["set", "{{.Name}}", "--cpus", "1"]
+    ]
   }],
   "provisioners": [{
     "type": "shell",

--- a/oracle57.json
+++ b/oracle57.json
@@ -60,6 +60,29 @@
       ["modifyvm", "{{.Name}}", "--memory", "512"],
       ["modifyvm", "{{.Name}}", "--cpus", "1"]
     ]
+  },
+  {
+    "vm_name": "oracle57",
+    "type": "parallels-iso",
+    "http_directory": "http",
+    "iso_url": "{{ user `iso_url` }}",
+    "iso_checksum": "{{ user `iso_checksum` }}",
+    "iso_checksum_type": "md5",
+    "parallels_tools_flavor": "lin",
+    "guest_os_type": "redhat",
+    "prlctl_version_file": ".prlctl_version",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_wait_timeout": "10000s",
+    "boot_command": [
+      "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort}}/ks5.cfg<enter>"
+    ],
+    "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -h now",
+    "disk_size": 10140,
+    "prlctl": [
+      ["set", "{{.Name}}", "--memsize", "512"],
+      ["set", "{{.Name}}", "--cpus", "1"]
+    ]
   }],
   "provisioners": [{
     "type": "shell",

--- a/oracle58-i386.json
+++ b/oracle58-i386.json
@@ -60,6 +60,29 @@
       ["modifyvm", "{{.Name}}", "--memory", "512"],
       ["modifyvm", "{{.Name}}", "--cpus", "1"]
     ]
+  },
+  {
+    "vm_name": "oracle58-i386",
+    "type": "parallels-iso",
+    "http_directory": "http",
+    "iso_url": "{{ user `iso_url` }}",
+    "iso_checksum": "{{ user `iso_checksum` }}",
+    "iso_checksum_type": "md5",
+    "parallels_tools_flavor": "lin",
+    "guest_os_type": "redhat",
+    "prlctl_version_file": ".prlctl_version",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_wait_timeout": "10000s",
+    "boot_command": [
+      "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort}}/ks5.cfg<enter>"
+    ],
+    "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -h now",
+    "disk_size": 10140,
+    "prlctl": [
+      ["set", "{{.Name}}", "--memsize", "512"],
+      ["set", "{{.Name}}", "--cpus", "1"]
+    ]
   }],
   "provisioners": [{
     "type": "shell",

--- a/oracle58.json
+++ b/oracle58.json
@@ -60,6 +60,29 @@
       ["modifyvm", "{{.Name}}", "--memory", "512"],
       ["modifyvm", "{{.Name}}", "--cpus", "1"]
     ]
+  },
+  {
+    "vm_name": "oracle58",
+    "type": "parallels-iso",
+    "http_directory": "http",
+    "iso_url": "{{ user `iso_url` }}",
+    "iso_checksum": "{{ user `iso_checksum` }}",
+    "iso_checksum_type": "md5",
+    "parallels_tools_flavor": "lin",
+    "guest_os_type": "redhat",
+    "prlctl_version_file": ".prlctl_version",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_wait_timeout": "10000s",
+    "boot_command": [
+      "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort}}/ks5.cfg<enter>"
+    ],
+    "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -h now",
+    "disk_size": 10140,
+    "prlctl": [
+      ["set", "{{.Name}}", "--memsize", "512"],
+      ["set", "{{.Name}}", "--cpus", "1"]
+    ]
   }],
   "provisioners": [{
     "type": "shell",

--- a/oracle59-i386.json
+++ b/oracle59-i386.json
@@ -60,6 +60,29 @@
       ["modifyvm", "{{.Name}}", "--memory", "512"],
       ["modifyvm", "{{.Name}}", "--cpus", "1"]
     ]
+  },
+  {
+    "vm_name": "oracle59-i386",
+    "type": "parallels-iso",
+    "http_directory": "http",
+    "iso_url": "{{ user `iso_url` }}",
+    "iso_checksum": "{{ user `iso_checksum` }}",
+    "iso_checksum_type": "md5",
+    "parallels_tools_flavor": "lin",
+    "guest_os_type": "redhat",
+    "prlctl_version_file": ".prlctl_version",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_wait_timeout": "10000s",
+    "boot_command": [
+      "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort}}/ks5.cfg<enter>"
+    ],
+    "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -h now",
+    "disk_size": 10140,
+    "prlctl": [
+      ["set", "{{.Name}}", "--memsize", "512"],
+      ["set", "{{.Name}}", "--cpus", "1"]
+    ]
   }],
   "provisioners": [{
     "type": "shell",

--- a/oracle59.json
+++ b/oracle59.json
@@ -60,6 +60,29 @@
       ["modifyvm", "{{.Name}}", "--memory", "512"],
       ["modifyvm", "{{.Name}}", "--cpus", "1"]
     ]
+  },
+  {
+    "vm_name": "oracle59",
+    "type": "parallels-iso",
+    "http_directory": "http",
+    "iso_url": "{{ user `iso_url` }}",
+    "iso_checksum": "{{ user `iso_checksum` }}",
+    "iso_checksum_type": "md5",
+    "parallels_tools_flavor": "lin",
+    "guest_os_type": "redhat",
+    "prlctl_version_file": ".prlctl_version",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_wait_timeout": "10000s",
+    "boot_command": [
+      "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort}}/ks5.cfg<enter>"
+    ],
+    "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -h now",
+    "disk_size": 10140,
+    "prlctl": [
+      ["set", "{{.Name}}", "--memsize", "512"],
+      ["set", "{{.Name}}", "--cpus", "1"]
+    ]
   }],
   "provisioners": [{
     "type": "shell",

--- a/oracle64-i386.json
+++ b/oracle64-i386.json
@@ -60,6 +60,29 @@
       ["modifyvm", "{{.Name}}", "--memory", "512"],
       ["modifyvm", "{{.Name}}", "--cpus", "1"]
     ]
+  },
+  {
+    "vm_name": "oracle64-i386",
+    "type": "parallels-iso",
+    "http_directory": "http",
+    "iso_url": "{{ user `iso_url` }}",
+    "iso_checksum": "{{ user `iso_checksum` }}",
+    "iso_checksum_type": "sha1",
+    "parallels_tools_flavor": "lin",
+    "guest_os_type": "redhat",
+    "prlctl_version_file": ".prlctl_version",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_wait_timeout": "10000s",
+    "boot_command": [
+      "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort}}/ks6.cfg<enter>"
+    ],
+    "shutdown_command": "echo 'vagrant'|sudo -S shutdown -h now",
+    "disk_size": 10140,
+    "prlctl": [
+      ["set", "{{.Name}}", "--memsize", "512"],
+      ["set", "{{.Name}}", "--cpus", "1"]
+    ]
   }],
   "provisioners": [{
     "type": "shell",

--- a/oracle64.json
+++ b/oracle64.json
@@ -60,6 +60,29 @@
       ["modifyvm", "{{.Name}}", "--memory", "512"],
       ["modifyvm", "{{.Name}}", "--cpus", "1"]
     ]
+  },
+  {
+    "vm_name": "oracle64",
+    "type": "parallels-iso",
+    "http_directory": "http",
+    "iso_url": "{{ user `iso_url` }}",
+    "iso_checksum": "{{ user `iso_checksum` }}",
+    "iso_checksum_type": "sha1",
+    "parallels_tools_flavor": "lin",
+    "guest_os_type": "redhat",
+    "prlctl_version_file": ".prlctl_version",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_wait_timeout": "10000s",
+    "boot_command": [
+      "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort}}/ks6.cfg<enter>"
+    ],
+    "shutdown_command": "echo 'vagrant'|sudo -S shutdown -h now",
+    "disk_size": 10140,
+    "prlctl": [
+      ["set", "{{.Name}}", "--memsize", "512"],
+      ["set", "{{.Name}}", "--cpus", "1"]
+    ]
   }],
   "provisioners": [{
     "type": "shell",

--- a/oracle65-desktop.json
+++ b/oracle65-desktop.json
@@ -60,6 +60,29 @@
       ["modifyvm", "{{.Name}}", "--memory", "512"],
       ["modifyvm", "{{.Name}}", "--cpus", "1"]
     ]
+  },
+  {
+    "vm_name": "oracle65-desktop",
+    "type": "parallels-iso",
+    "http_directory": "http",
+    "iso_url": "{{ user `iso_url` }}",
+    "iso_checksum": "{{ user `iso_checksum` }}",
+    "iso_checksum_type": "sha1",
+    "parallels_tools_flavor": "lin",
+    "guest_os_type": "redhat",
+    "prlctl_version_file": ".prlctl_version",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_wait_timeout": "10000s",
+    "boot_command": [
+      "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort}}/ks6-desktop.cfg<enter>"
+    ],
+    "shutdown_command": "echo 'vagrant'|sudo -S shutdown -h now",
+    "disk_size": 40960,
+    "prlctl": [
+      ["set", "{{.Name}}", "--memsize", "512"],
+      ["set", "{{.Name}}", "--cpus", "1"]
+    ]
   }],
   "provisioners": [{
     "type": "shell",

--- a/oracle65-i386.json
+++ b/oracle65-i386.json
@@ -60,6 +60,29 @@
       ["modifyvm", "{{.Name}}", "--memory", "512"],
       ["modifyvm", "{{.Name}}", "--cpus", "1"]
     ]
+  },
+  {
+    "vm_name": "oracle65-i386",
+    "type": "parallels-iso",
+    "http_directory": "http",
+    "iso_url": "{{ user `iso_url` }}",
+    "iso_checksum": "{{ user `iso_checksum` }}",
+    "iso_checksum_type": "sha1",
+    "parallels_tools_flavor": "lin",
+    "guest_os_type": "redhat",
+    "prlctl_version_file": ".prlctl_version",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_wait_timeout": "10000s",
+    "boot_command": [
+      "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort}}/ks6.cfg<enter>"
+    ],
+    "shutdown_command": "echo 'vagrant'|sudo -S shutdown -h now",
+    "disk_size": 10140,
+    "prlctl": [
+      ["set", "{{.Name}}", "--memsize", "512"],
+      ["set", "{{.Name}}", "--cpus", "1"]
+    ]
   }],
   "provisioners": [{
     "type": "shell",

--- a/oracle65.json
+++ b/oracle65.json
@@ -60,6 +60,29 @@
       ["modifyvm", "{{.Name}}", "--memory", "512"],
       ["modifyvm", "{{.Name}}", "--cpus", "1"]
     ]
+  },
+  {
+    "vm_name": "oracle65",
+    "type": "parallels-iso",
+    "http_directory": "http",
+    "iso_url": "{{ user `iso_url` }}",
+    "iso_checksum": "{{ user `iso_checksum` }}",
+    "iso_checksum_type": "sha1",
+    "parallels_tools_flavor": "lin",
+    "guest_os_type": "redhat",
+    "prlctl_version_file": ".prlctl_version",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_wait_timeout": "10000s",
+    "boot_command": [
+      "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort}}/ks6.cfg<enter>"
+    ],
+    "shutdown_command": "echo 'vagrant'|sudo -S shutdown -h now",
+    "disk_size": 20480,
+    "prlctl": [
+      ["set", "{{.Name}}", "--memsize", "512"],
+      ["set", "{{.Name}}", "--cpus", "1"]
+    ]
   }],
   "provisioners": [{
     "type": "shell",

--- a/oracle70-desktop.json
+++ b/oracle70-desktop.json
@@ -61,6 +61,29 @@
       ["modifyvm", "{{.Name}}", "--memory", "1024"],
       ["modifyvm", "{{.Name}}", "--cpus", "1"]
     ]
+  },
+  {
+    "vm_name": "oracle70-desktop",
+    "type": "parallels-iso",
+    "http_directory": "http",
+    "iso_url": "{{ user `iso_url` }}",
+    "iso_checksum": "{{ user `iso_checksum` }}",
+    "iso_checksum_type": "sha1",
+    "parallels_tools_flavor": "lin",
+    "guest_os_type": "redhat",
+    "prlctl_version_file": ".prlctl_version",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_wait_timeout": "10000s",
+    "boot_command": [
+      "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort}}/ks7-desktop.cfg<enter>"
+    ],
+    "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+    "disk_size": 40960,
+    "prlctl": [
+      ["set", "{{.Name}}", "--memsize", "1024"],
+      ["set", "{{.Name}}", "--cpus", "1"]
+    ]
   }],
   "provisioners": [{
     "type": "shell",

--- a/oracle70.json
+++ b/oracle70.json
@@ -61,6 +61,29 @@
       ["modifyvm", "{{.Name}}", "--memory", "512"],
       ["modifyvm", "{{.Name}}", "--cpus", "1"]
     ]
+  },
+  {
+    "vm_name": "oracle70",
+    "type": "parallels-iso",
+    "http_directory": "http",
+    "iso_url": "{{ user `iso_url` }}",
+    "iso_checksum": "{{ user `iso_checksum` }}",
+    "iso_checksum_type": "sha1",
+    "parallels_tools_flavor": "lin",
+    "guest_os_type": "redhat",
+    "prlctl_version_file": ".prlctl_version",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_wait_timeout": "10000s",
+    "boot_command": [
+      "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort}}/ks7.cfg<enter>"
+    ],
+    "shutdown_command": "echo 'vagrant'|sudo -S shutdown -h now",
+    "disk_size": 20480,
+    "prlctl": [
+      ["set", "{{.Name}}", "--memsize", "512"],
+      ["set", "{{.Name}}", "--cpus", "1"]
+    ]
   }],
   "provisioners": [{
     "type": "shell",

--- a/script/vmtool.sh
+++ b/script/vmtool.sh
@@ -27,7 +27,7 @@ install_vmware_tools_centos_70()
         popd
         tar cf vmhgfs.tar vmhgfs-only
         rm -rf vmhgfs-only
-        popd        
+        popd
     fi
 
     umount /mnt/floppy
@@ -40,7 +40,7 @@ install_vmware_tools_centos_70()
 
     echo "==> Removing packages needed for building guest tools"
     yum -y remove gcc cpp kernel-devel kernel-headers perl
-    
+
     exit
 }
 
@@ -92,6 +92,16 @@ if [[ $PACKER_BUILDER_TYPE =~ virtualbox ]]; then
     if [[ $VBOX_VERSION = "4.3.10" ]]; then
         ln -s /opt/VBoxGuestAdditions-4.3.10/lib/VBoxGuestAdditions /usr/lib/VBoxGuestAdditions
     fi
+fi
+
+if [[ $PACKER_BUILDER_TYPE =~ parallels ]]; then
+    echo "==> Installing Parallels tools"
+
+    mount -o loop /home/vagrant/prl-tools-lin.iso /mnt
+    /mnt/install --install-unattended-with-deps
+    umount /mnt
+    rm -rf /home/vagrant/prl-tools-lin.iso
+    rm -f /home/vagrant/.prlctl_version
 fi
 
 echo "==> Removing packages needed for building guest tools"


### PR DESCRIPTION
Support building vagrant boxes for Parallels Desktop for Mac.

Requires Parallels Desktop 9+ and packer v 0.7.0.
